### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 國立交通大學 課程時間表
 
-+ [更改紀錄 Commit log](commits)
++ [更改紀錄 Commit log](../../commits)
 + [108 學年度 下學期](pretty-108-2.json)
 + [108 學年度 上學期](pretty-108-1.json)
 


### PR DESCRIPTION
fix relative path of commit log in README.md
and the absolute path of it is 'https://github.com/Sea-n/nctu-timetable/commits/master'